### PR TITLE
Fixed the currency list

### DIFF
--- a/lib/locales/en/finance/currency.js
+++ b/lib/locales/en/finance/currency.js
@@ -71,9 +71,9 @@ module["exports"] = {
     "code": "BND",
     "symbol": "$"
   },
-  "Boliviano Mvdol": {
-    "code": "BOB BOV",
-    "symbol": "$b"
+  "Boliviano boliviano": {
+    "code": "BOB",
+    "symbol": "Bs"
   },
   "Brazilian Real": {
     "code": "BRL",
@@ -107,25 +107,29 @@ module["exports"] = {
     "code": "CHF",
     "symbol": "CHF"
   },
-  "Chilean Peso Unidades de fomento": {
-    "code": "CLP CLF",
+  "Chilean Peso": {
+    "code": "CLP",
     "symbol": "$"
   },
   "Yuan Renminbi": {
     "code": "CNY",
     "symbol": "¥"
   },
-  "Colombian Peso Unidad de Valor Real": {
-    "code": "COP COU",
+  "Colombian Peso": {
+    "code": "COP",
     "symbol": "$"
   },
   "Costa Rican Colon": {
     "code": "CRC",
     "symbol": "₡"
   },
-  "Cuban Peso Peso Convertible": {
-    "code": "CUP CUC",
+  "Cuban Peso": {
+    "code": "CUP",
     "symbol": "₱"
+  },
+  "Cuban Peso Convertible": {
+    "code": "CUC",
+    "symbol": "$"
   },
   "Cape Verde Escudo": {
     "code": "CVE",
@@ -223,8 +227,8 @@ module["exports"] = {
     "code": "HRK",
     "symbol": "kn"
   },
-  "Gourde US Dollar": {
-    "code": "HTG USD",
+  "Gourde": {
+    "code": "HTG",
     "symbol": ""
   },
   "Forint": {
@@ -243,9 +247,13 @@ module["exports"] = {
     "code": "INR",
     "symbol": ""
   },
-  "Indian Rupee Ngultrum": {
-    "code": "INR BTN",
-    "symbol": ""
+  "Bhutanese Ngultrum": {
+    "code": "BTN",
+    "symbol": "Nu"
+  },
+  "Indian Rupee": {
+    "code": "INR",
+    "symbol": "₹"
   },
   "Iraqi Dinar": {
     "code": "IQD",
@@ -379,8 +387,8 @@ module["exports"] = {
     "code": "MWK",
     "symbol": ""
   },
-  "Mexican Peso Mexican Unidad de Inversion (UDI)": {
-    "code": "MXN MXV",
+  "Mexican Peso": {
+    "code": "MXN",
     "symbol": "$"
   },
   "Malaysian Ringgit": {
@@ -507,9 +515,9 @@ module["exports"] = {
     "code": "STD",
     "symbol": ""
   },
-  "El Salvador Colon US Dollar": {
-    "code": "SVC USD",
-    "symbol": "$"
+  "El Salvador Colon": {
+    "code": "SVC",
+    "symbol": "₡"
   },
   "Syrian Pound": {
     "code": "SYP",
@@ -567,8 +575,8 @@ module["exports"] = {
     "code": "USD",
     "symbol": "$"
   },
-  "Peso Uruguayo Uruguay Peso en Unidades Indexadas": {
-    "code": "UYU UYI",
+  "Peso Uruguayo": {
+    "code": "UYU",
     "symbol": "$U"
   },
   "Uzbekistan Sum": {
@@ -659,13 +667,13 @@ module["exports"] = {
     "code": "ZAR",
     "symbol": "R"
   },
-  "Rand Loti": {
-    "code": "ZAR LSL",
+  "Lesotho Loti": {
+    "code": "LSL",
     "symbol": ""
   },
-  "Rand Namibia Dollar": {
-    "code": "ZAR NAD",
-    "symbol": ""
+  "Namibia Dollar": {
+    "code": "NAD",
+    "symbol": "N$"
   },
   "Zambian Kwacha": {
     "code": "ZMK",


### PR DESCRIPTION
Previously this list included invalid ISO4217 codes, probably as a result of the parser/generator that was used to create the list.

I've split all of the combined codes, and removed some of the [fund code](https://en.wikipedia.org/wiki/Unidad_de_Fomento) codes.

I've also taken the time to give some the currencies their correct names and symbols according to their respective wikipedia pages.